### PR TITLE
Fix app crashes when emulator/device is selected

### DIFF
--- a/src/main/kotlin/com/theapache64/stackzy/ui/feature/selectapp/SelectAppViewModel.kt
+++ b/src/main/kotlin/com/theapache64/stackzy/ui/feature/selectapp/SelectAppViewModel.kt
@@ -77,7 +77,7 @@ class SelectAppViewModel @Inject constructor(
         when (apkSource) {
             is ApkSource.Adb -> {
                 // ### ADB ###
-                this.selectedDevice = (apkSource as ApkSource.Adb<AndroidDevice>).value
+                this.selectedDevice = (apkSource as ApkSource.Adb<AndroidDeviceWrapper>).value.androidDevice
                 viewModelScope.launch {
                     fullApps = adbRepo.getInstalledApps(selectedDevice!!.device)
                     val tab = if (selectedTabIndex.value == TAB_NO_TAB) {


### PR DESCRIPTION
While testing the app we found two bugs which was related to adb source selection. 
1- Wrong cast apk source 
Steps:
- Connect android device or Launch android emulator
- Select pathway adb
- Select device
- Observer

App is crashing with exception 
```
 class com.theapache64.stackzy.model.AndroidDeviceWrapper cannot be cast to class com.theapache64.stackzy.data.local.AndroidDevice (com.theapache64.stackzy.model.AndroidDeviceWrapper and com.theapache64.stackzy.data.local.AndroidDevice are in unnamed module of loader 'app')
```

The issue is we are casting to wrong type
The fix is in commit: 7c9a7e115d1ff75f27414395825596b250527472

2- AndroidApp with empty package name
Steps: 
- Fix first bug
- Connect android device or Launch android emulator
- Select pathway adb
- Select device
- Observer

App is crashing with exception 
```
Char sequence is empty.
	at kotlin.text.StringsKt___StringsKt.first(_Strings.kt:71)
	at com.theapache64.stackzy.model.AndroidAppWrapper.getAlphabet(AndroidAppWrapper.kt:28)
```
The issue is `pm list packages` is returning string which ends with `\n` and when we split the string we create a package with empty string. 
The fix is in commit: 7c9a7e115d1ff75f27414395825596b250527472

Unfortunate I was unable to add test for the `SelectAppViewModel` because unit test was failing with weird exception 
```
@Composable functions must be marked with the @Composable annotation
```